### PR TITLE
Fix #10: @ReturnValuesAreNonnullByDefault should allow @Nonnull on ov…

### DIFF
--- a/src/de/bjrke/checkstyle/jsr305/Jsr305Annotations.java
+++ b/src/de/bjrke/checkstyle/jsr305/Jsr305Annotations.java
@@ -305,10 +305,12 @@ public class Jsr305Annotations extends Check {
             final boolean returnValuesAreNonnullByDefault = getParentMethodOrClassAnnotation( NullnessAnnotation.RETURN_VALUES_ARE_NONNULL_BY_DEFAULT ) == NullnessAnnotation.RETURN_VALUES_ARE_NONNULL_BY_DEFAULT;
             final boolean isMethodOverridden = isMethodOverridden();
 
-            if ( returnValuesAreNonnullByDefault ) {
-                checkContainsAny(
-                        "It is not necessary to annotate @Nonnull if you annoted the class with @ReturnValuesAreNonnullByDefault.",
-                        NullnessAnnotation.NONNULL );
+            if (returnValuesAreNonnullByDefault) {
+                if (!isMethodOverridden) {
+                    checkContainsAny(
+                            "It is not necessary to annotate @Nonnull if you annoted the class with @ReturnValuesAreNonnullByDefault.",
+                            NullnessAnnotation.NONNULL);
+                }
             } else {
                 checkContainsNone( "Returnvalue must have nullness Annotation (@Nonnull or @CheckForNull)!",
                         NullnessAnnotation.CHECK_FOR_NULL, NullnessAnnotation.NONNULL, NullnessAnnotation.OVERRIDE );

--- a/test/de/bjrke/checkstyle/jsr305/Jsr305AnnotationsTest.java
+++ b/test/de/bjrke/checkstyle/jsr305/Jsr305AnnotationsTest.java
@@ -6,6 +6,7 @@ import de.bjrke.checkstyle.jsr305.Jsr305AnnationsTestUtil.ExpectedWarning;
 import de.bjrke.checkstyle.jsr305.test.ArraysTestObject;
 import de.bjrke.checkstyle.jsr305.test.ClassTestObject;
 import de.bjrke.checkstyle.jsr305.test.ConstructorTestObject;
+import de.bjrke.checkstyle.jsr305.test.DefaultParameterTestObject;
 import de.bjrke.checkstyle.jsr305.test.DefectConstructorTest;
 import de.bjrke.checkstyle.jsr305.test.ParameterTestObject;
 import de.bjrke.checkstyle.jsr305.test.PrimitivesTestObject;
@@ -75,7 +76,9 @@ public class Jsr305AnnotationsTest {
                 new ExpectedWarning( ClassTestObject.class, 279, 37 ), //
                 new ExpectedWarning( ClassTestObject.class, 296, 9 ), //
                 new ExpectedWarning( ClassTestObject.class, 302, 9 ), //
-                new ExpectedWarning( ClassTestObject.class, 315, 5 ) //
+                new ExpectedWarning( ClassTestObject.class, 315, 5 ), //
+
+                new ExpectedWarning(DefaultParameterTestObject.class, 18, 5) //
                 );
     }
 }

--- a/test/de/bjrke/checkstyle/jsr305/test/DefaultParameterTestObject.java
+++ b/test/de/bjrke/checkstyle/jsr305/test/DefaultParameterTestObject.java
@@ -1,0 +1,23 @@
+package de.bjrke.checkstyle.jsr305.test;
+
+import javax.annotation.Nonnull;
+
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+
+@ReturnValuesAreNonnullByDefault
+public class DefaultParameterTestObject implements TestInterface {
+
+    // ok
+    @Override
+    @Nonnull
+    public Object foo() {
+        return new Object();
+    }
+
+    // error
+    @Nonnull
+    public Object bar() {
+        return new Object();
+    }
+
+}

--- a/test/de/bjrke/checkstyle/jsr305/test/TestInterface.java
+++ b/test/de/bjrke/checkstyle/jsr305/test/TestInterface.java
@@ -1,0 +1,9 @@
+package de.bjrke.checkstyle.jsr305.test;
+
+import javax.annotation.CheckForNull;
+
+public interface TestInterface {
+
+    @CheckForNull
+    Object foo();
+}


### PR DESCRIPTION
…erriden methods

The annotation @ReturnValuesAreNonnullByDefault does
not cover methods that override a super class method.
Therefore a @Nonnull-Annotation should be allowed for the return value.